### PR TITLE
Fixes

### DIFF
--- a/src/main/scala/iotaz/instances/EqualKHelper.scala
+++ b/src/main/scala/iotaz/instances/EqualKHelper.scala
@@ -33,10 +33,11 @@ object EqualKHelper {
     type CP[B] = CopK[F ::: TNilK, B]
 
     def materialize(offset: Int): Equal[CP[A]] = {
-      val FA = CopK.Inject[F, CP]
+      val FA = mkInject[F, F ::: TNilK](offset)
 
-      Equal equalBy {
-        case FA(fa) => fa
+      Equal equal {
+        case (FA(left), FA(right)) => eql.equal(left, right)
+        case _ => false
       }
     }
   }
@@ -45,11 +46,11 @@ object EqualKHelper {
     type CP[B] = CopK[F ::: LL, B]
 
     def materialize(offset: Int): Equal[CP[A]] = {
-      val FA = mkInject[F, F ::: LL](0)
+      val FA = mkInject[F, F ::: LL](offset)
 
       Equal equal {
         case (FA(left), FA(right)) => eql.equal(left, right)
-        case (left, right) => LL.materialize(0).equal(left.asInstanceOf[CopK[LL, A]], right.asInstanceOf[CopK[LL, A]])
+        case (left, right) => LL.materialize(offset + 1).equal(left.asInstanceOf[CopK[LL, A]], right.asInstanceOf[CopK[LL, A]])
       }
     }
   }

--- a/src/main/scala/iotaz/instances/EqualKHelper.scala
+++ b/src/main/scala/iotaz/instances/EqualKHelper.scala
@@ -55,11 +55,4 @@ object EqualKHelper {
     }
   }
 
-  private def mkInject[F[_], LL <: TListK](i: Int): CopK.Inject[F, CopK[LL, ?]] = {
-    CopK.Inject.injectFromInjectL[F, LL](
-      CopK.InjectL.makeInjectL[F, LL](
-        new TListK.Pos[LL, F] { val index: Int = i }
-      )
-    )
-  }
 }

--- a/src/main/scala/iotaz/instances/EqualKHelper.scala
+++ b/src/main/scala/iotaz/instances/EqualKHelper.scala
@@ -29,16 +29,9 @@ sealed trait EqualKHelper[LL <: TListK, A] {
 
 object EqualKHelper {
 
-  implicit def base[F[_], A](implicit eql: Equal[F[A]]): EqualKHelper[F ::: TNilK, A] = new EqualKHelper[F ::: TNilK, A] {
-    type CP[B] = CopK[F ::: TNilK, B]
-
-    def materialize(offset: Int): Equal[CP[A]] = {
-      val FA = mkInject[F, F ::: TNilK](offset)
-
-      Equal equal {
-        case (FA(left), FA(right)) => eql.equal(left, right)
-        case _ => false
-      }
+  implicit def base[A]: EqualKHelper[TNilK, A] = new EqualKHelper[TNilK, A] {
+    def materialize(offset: Int): Equal[CopK[TNilK, A]] = {
+      Equal equal { (_, _) => false }
     }
   }
 

--- a/src/main/scala/iotaz/instances/TraverseMaterializer.scala
+++ b/src/main/scala/iotaz/instances/TraverseMaterializer.scala
@@ -30,11 +30,7 @@ object TraverseMaterializer {
 
   implicit val base: TraverseMaterializer[TNilK] = new TraverseMaterializer[TNilK] {
     override def materialize(offset: Int): Traverse[CopK[TNilK, ?]] = {
-      new Traverse[CopK[TNilK, ?]] {
-        override def traverseImpl[G[_], A, B](cfa: CopK[TNilK, A])(f: A => G[B])(implicit A: Applicative[G]): G[CopK[TNilK, B]] = {
-          ???
-        }
-      }
+      ???
     }
   }
 

--- a/src/main/scala/iotaz/instances/TraverseMaterializer.scala
+++ b/src/main/scala/iotaz/instances/TraverseMaterializer.scala
@@ -28,15 +28,11 @@ sealed trait TraverseMaterializer[LL <: TListK] {
 
 object TraverseMaterializer {
 
-  implicit def base[F[_]](implicit F: Traverse[F]): TraverseMaterializer[F ::: TNilK] = new TraverseMaterializer[F ::: TNilK] {
-    override def materialize(offset: Int): Traverse[CopK[F ::: TNilK, ?]] = {
-      val I = mkInject[F, F ::: TNilK](offset)
-
-      new Traverse[CopK[F ::: TNilK, ?]] {
-        override def traverseImpl[G[_], A, B](cfa: CopK[F ::: TNilK, A])(f: A => G[B])(implicit A: Applicative[G]): G[CopK[F ::: TNilK, B]] = {
-          cfa match {
-            case I(fa) => A.map(F.traverse(fa)(f))(I(_))
-          }
+  implicit val base: TraverseMaterializer[TNilK] = new TraverseMaterializer[TNilK] {
+    override def materialize(offset: Int): Traverse[CopK[TNilK, ?]] = {
+      new Traverse[CopK[TNilK, ?]] {
+        override def traverseImpl[G[_], A, B](cfa: CopK[TNilK, A])(f: A => G[B])(implicit A: Applicative[G]): G[CopK[TNilK, B]] = {
+          ???
         }
       }
     }

--- a/src/main/scala/iotaz/instances/TraverseMaterializer.scala
+++ b/src/main/scala/iotaz/instances/TraverseMaterializer.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iotaz.instances
+
+import iotaz.TListK.:::
+import iotaz.{ CopK, TListK, TNilK }
+import scalaz.{ Applicative, Traverse }
+
+import scala.language.higherKinds
+
+sealed trait TraverseMaterializer[LL <: TListK] {
+  def materialize(offset: Int): Traverse[CopK[LL, ?]]
+}
+
+object TraverseMaterializer {
+
+  implicit def base[F[_]](implicit F: Traverse[F]): TraverseMaterializer[F ::: TNilK] = new TraverseMaterializer[F ::: TNilK] {
+    override def materialize(offset: Int): Traverse[CopK[F ::: TNilK, ?]] = {
+      val I = mkInject[F, F ::: TNilK](offset)
+
+      new Traverse[CopK[F ::: TNilK, ?]] {
+        override def traverseImpl[G[_], A, B](cfa: CopK[F ::: TNilK, A])(f: A => G[B])(implicit A: Applicative[G]): G[CopK[F ::: TNilK, B]] = {
+          cfa match {
+            case I(fa) => A.map(F.traverse(fa)(f))(I(_))
+          }
+        }
+      }
+    }
+  }
+
+  implicit def induct[F[_], LL <: TListK](
+    implicit
+    F: Traverse[F],
+    LL: TraverseMaterializer[LL]
+  ): TraverseMaterializer[F ::: LL] = new TraverseMaterializer[F ::: LL] {
+    override def materialize(offset: Int): Traverse[CopK[TListK.:::[F, LL], ?]] = {
+      val I = mkInject[F, F ::: LL](offset)
+
+      new Traverse[CopK[F ::: LL, ?]] {
+        override def traverseImpl[G[_], A, B](cfa: CopK[F ::: LL, A])(f: A => G[B])(implicit A: Applicative[G]): G[CopK[F ::: LL, B]] = {
+          cfa match {
+            case I(fa) => A.map(F.traverse(fa)(f))(I(_))
+            case other => LL.materialize(offset + 1).traverseImpl(other.asInstanceOf[CopK[LL, A]])(f).asInstanceOf[G[iotaz.CopK[F ::: LL,B]]]
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/scala/iotaz/instances/package.scala
+++ b/src/main/scala/iotaz/instances/package.scala
@@ -21,5 +21,5 @@ import scalaz.Equal
 package object instances {
 
   implicit def equalForCopK[LL <: TListK, A](implicit EH: EqualKHelper[LL, A]): Equal[CopK[LL, A]] =
-    EH.materialize
+    EH.materialize(0)
 }

--- a/src/main/scala/iotaz/instances/package.scala
+++ b/src/main/scala/iotaz/instances/package.scala
@@ -16,10 +16,23 @@
 
 package iotaz
 
-import scalaz.Equal
+import scalaz.{ Equal, Traverse }
+
+import scala.language.higherKinds
 
 package object instances {
 
+  private[instances] def mkInject[F[_], LL <: TListK](i: Int): CopK.Inject[F, CopK[LL, ?]] = {
+    CopK.Inject.injectFromInjectL[F, LL](
+      CopK.InjectL.makeInjectL[F, LL](
+        new TListK.Pos[LL, F] { val index: Int = i }
+      )
+    )
+  }
+
   implicit def equalForCopK[LL <: TListK, A](implicit EH: EqualKHelper[LL, A]): Equal[CopK[LL, A]] =
     EH.materialize(0)
+
+  implicit def traverseForCopK[LL <: TListK](implicit TM: TraverseMaterializer[LL]): Traverse[CopK[LL, ?]] =
+    TM.materialize(0)
 }

--- a/src/test/scala/iotaz/instances/EqualSpecs.scala
+++ b/src/test/scala/iotaz/instances/EqualSpecs.scala
@@ -24,10 +24,12 @@ import TListK.:::
 object EqualSpecs extends Specification {
 
   "equal materialization" should {
-    type CP[A] = CopK[List ::: Option ::: TNilK, A]
+    type CP[A] = CopK[List ::: Option ::: Vector ::: (Int \/ ?) ::: TNilK, A]
 
     val LI = CopK.Inject[List, CP]
     val OI = CopK.Inject[Option, CP]
+    val VI = CopK.Inject[Vector, CP]
+    val EI = CopK.Inject[Int \/ ?, CP]
 
     "materialize first component match true" in {
       val test1 = LI(List(1, 2, 3))
@@ -55,18 +57,34 @@ object EqualSpecs extends Specification {
       (test1 === test2) must beFalse
     }
 
-    "materialize second component match false" in {
-      val test1 = OI(Some("forty-two"))
-      val test2 = OI(Some("other-things"))
-
-      (test1 === test2) must beFalse
-    }
-
     "materialize both components match false" in {
       val test1 = LI(List(1, 2, 3, 4))
       val test2 = OI(Some(123))
 
       (test1 === test2) must beFalse
     }
+
+    "materialize last component match true" in {
+      val test1 = EI(":)".right[Int])
+      val test2 = EI(":)".right[Int])
+
+      (test1 === test2) must beTrue
+    }
+
+    "materialize last component match false" in {
+      val test1 = EI(":)".right[Int])
+      val test2 = EI(7.left[String])
+
+      (test1 === test2) must beFalse
+    }
+
+    "materialize last and second to last component match false" in {
+      val test1 = EI(":)".right[Int])
+      val test2 = VI(Vector(":D", ":DD"))
+
+      (test1 === test2) must beFalse
+    }
+
   }
+
 }

--- a/src/test/scala/iotaz/instances/EqualSpecs.scala
+++ b/src/test/scala/iotaz/instances/EqualSpecs.scala
@@ -19,7 +19,6 @@ package instances
 
 import org.specs2.mutable._
 import scalaz._, Scalaz._
-import scalaz.syntax.equal
 import TListK.:::
 
 object EqualSpecs extends Specification {
@@ -63,11 +62,11 @@ object EqualSpecs extends Specification {
       (test1 === test2) must beFalse
     }
 
-    /*"materialize both components match false" in {
+    "materialize both components match false" in {
       val test1 = LI(List(1, 2, 3, 4))
-      val test2 = OI(Some("other-things"))
+      val test2 = OI(Some(123))
 
       (test1 === test2) must beFalse
-    }*/
+    }
   }
 }

--- a/src/test/scala/iotaz/instances/EqualSpecs.scala
+++ b/src/test/scala/iotaz/instances/EqualSpecs.scala
@@ -19,6 +19,7 @@ package instances
 
 import org.specs2.mutable._
 import scalaz._, Scalaz._
+import scalaz.syntax.equal
 import TListK.:::
 
 object EqualSpecs extends Specification {

--- a/src/test/scala/iotaz/instances/TraverseSpecs.scala
+++ b/src/test/scala/iotaz/instances/TraverseSpecs.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package iotaz.instances
+
+import iotaz.{ CopK, TNilK }
+import iotaz.TListK.:::
+import org.specs2.mutable.Specification
+import scalaz._, Scalaz._
+
+object TraverseSpecs extends Specification {
+
+  "traverse materialization" should {
+    type CP[A] = CopK[List ::: Option ::: Vector ::: TNilK, A]
+    val LI = CopK.Inject[List, CP]
+    val OI = CopK.Inject[Option, CP]
+    val VI = CopK.Inject[Vector, CP]
+
+    "materialize first element" in {
+      val test = LI(List(1, 2, 3))
+
+      val traversed = test.traverse(x => (x + 1).toString.right[String])
+
+      traversed must beEqualTo(LI(List("2", "3", "4")).right[String])
+    }
+
+    "materialize second element" in {
+      val test = OI(":)".some)
+
+      val traversed = test.traverse(s => List(s, s))
+
+      traversed must beEqualTo(List(OI(":)".some), OI(":)".some)))
+    }
+
+    "materialize last element" in {
+      val test = VI(Vector(":)", ":D", ":>"))
+
+      val traversed = test.traverse(x => s"[$x]".some)
+
+      traversed must beEqualTo(VI(Vector("[:)]", "[:D]", "[:>]")).some)
+    }
+  }
+
+}


### PR DESCRIPTION
I got the tests to pass. I added offset parameter to `materialize` method. This allows to specify the index at which things should start matching. I also added `case _ => false` in `base` case to handle coproducts that do not match.
I also uncommented one of the tests, it didn't compile because of A type was different for those coproducts. I made list longer, as I didn't trust it will work, but luckily it did.

I plan to prepare instance for `Traverse`, generally write more instances and hopefully try to extract some common parts as it is a bit verbose now.

I will also look at more complex stuff. I have a rather vague understanding of `matryoshka.Delay`. Thus I don't know if the current implementation in iota-instances will be enough. I will try to experiment to create a version with Delay and with other more complex examples.